### PR TITLE
correctly truncate messages in syslog sink

### DIFF
--- a/syslog_sink.go
+++ b/syslog_sink.go
@@ -5,7 +5,10 @@ import (
 	"sync"
 )
 
-const MaxMessageSize = 1024 * 3
+const (
+	MaxMessageSize  = 1024 * 3
+	TruncatePostfix = "..."
+)
 
 type Syslog struct {
 	writer *syslog.Writer
@@ -73,5 +76,5 @@ func truncate(record *Record) {
 		return
 	}
 
-	record.Message = record.Message[:MaxMessageSize] + "..."
+	record.Message = record.Message[:MaxMessageSize-len(TruncatePostfix)] + TruncatePostfix
 }

--- a/syslog_sink_test.go
+++ b/syslog_sink_test.go
@@ -25,8 +25,8 @@ func (s *SyslogSinkSuite) TestTruncate(c *C) {
 		Message: msg2,
 	}
 	truncate(record2)
-	c.Check(len(record2.Message), Equals, MaxMessageSize+len("..."))
-	c.Check(record2.Message[:MaxMessageSize], Equals, msg2[:MaxMessageSize])
+	c.Check(len(record2.Message), Equals, MaxMessageSize)
+	c.Check(record2.Message[:MaxMessageSize-3], Equals, msg2[:MaxMessageSize-3])
 	c.Check(strings.HasSuffix(record2.Message, "..."), Equals, true)
 }
 


### PR DESCRIPTION
Instead of removing one character and adding three (...), remove the correct amount

Signed-off-by: Glenn Oppegard goppegard@pivotallabs.com
