### PR TITLE
Remove syslog from windows builds

### DIFF
--- a/syslog_sink.go
+++ b/syslog_sink.go
@@ -1,3 +1,5 @@
+// +build !windows,!plan9
+
 package gosteno
 
 import (

--- a/syslog_sink_test.go
+++ b/syslog_sink_test.go
@@ -1,3 +1,5 @@
+// +build !windows,!plan9
+
 package gosteno
 
 import (


### PR DESCRIPTION
To build the directory service on windows, need to remove syslog.
